### PR TITLE
Bug Fix - Cannot X out of MacroMenu

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -4,8 +4,8 @@
 namespace gui
 {
 	//bool playing = false;
-	void ShowMacroMenu(bool p_open) {
-		ImGui::Begin("MacroMenu", &p_open, default_window_flags);
+	void ShowMacroMenu(bool* p_open) {
+		ImGui::Begin("MacroMenu", p_open, default_window_flags);
 		ImGui::GetWindowViewport()->Flags = default_viewport_flags;
 
 		std::vector<Macro> macros;

--- a/src/gui.h
+++ b/src/gui.h
@@ -16,7 +16,7 @@ namespace gui
 		ImGuiViewportFlags_TopMost |
 		ImGuiViewportFlags_NoTaskBarIcon;
 
-	void ShowMacroMenu(bool p_open);
+	void ShowMacroMenu(bool* p_open);
 
 #pragma region TextureButton
 	void LoadNativeTextures();

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -9,6 +9,10 @@ namespace render
 		{
 			gui::ShowMacroMenu(&show_macro_menu);
 		}
+		else
+		{
+			done = true;
+		}
 	}
 	void BeginRender()
 	{

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -153,7 +153,7 @@ namespace render
 		//ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, nullptr, io.Fonts->GetGlyphRangesJapanese());
 		//IM_ASSERT(font != nullptr);
 		gui::LoadNativeTextures();
-		}
+	}
 	void Cleanup()
 	{
 		// Cleanup
@@ -165,4 +165,4 @@ namespace render
 		SDL_DestroyWindow(window);
 		SDL_Quit();
 	}
-	}
+}

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -5,7 +5,7 @@ namespace render
 	void Render()
 	{
 		//ImGui::ShowDemoWindow();
-		if (show_macro_menu)
+		if (show_macro_menu) // stop showing Macro Menu when window closed
 		{
 			gui::ShowMacroMenu(&show_macro_menu);
 		}

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -5,9 +5,11 @@ namespace render
 	void Render()
 	{
 		//ImGui::ShowDemoWindow();
-		gui::ShowMacroMenu(&show_macro_menu);
+		if (show_macro_menu)
+		{
+			gui::ShowMacroMenu(&show_macro_menu);
+		}
 	}
-
 	void BeginRender()
 	{
 		// Poll and handle events (inputs, window resize, etc.)
@@ -147,7 +149,7 @@ namespace render
 		//ImFont* font = io.Fonts->AddFontFromFileTTF("c:\\Windows\\Fonts\\ArialUni.ttf", 18.0f, nullptr, io.Fonts->GetGlyphRangesJapanese());
 		//IM_ASSERT(font != nullptr);
 		gui::LoadNativeTextures();
-	}
+		}
 	void Cleanup()
 	{
 		// Cleanup
@@ -159,4 +161,4 @@ namespace render
 		SDL_DestroyWindow(window);
 		SDL_Quit();
 	}
-}
+	}

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -9,7 +9,7 @@ namespace render
 		{
 			gui::ShowMacroMenu(&show_macro_menu);
 		}
-		else
+		else // end program if Macro Menu (and other windows rendered here) is closed
 		{
 			done = true;
 		}


### PR DESCRIPTION
This fixes #22 

Changes were tested using `Visual Studio 2022` on `Release 86` configurations 

Summary of Changes
---
Modified the following files:
- `src/gui.h`
  - Changed `ShowMacroMenu()` prototype to take pointer type parameter
- `src/gui.cpp`
  - Adjusted `ShowMacroMenu()` implementation to match prototype changes
- `src/render.cpp`
  - Changed `Render()` to stop calling `gui::ShowMacroMenu()` when Macro Menu is closed (when `show_macro_menu` set to false) and to end program if no other windows are open.

Reasons for Changes
---
Modifying `ShowMacroMenu()`
- Although `p_open` is being passed by reference to `ImGui::Begin()`, it looks like `p_open` itself was being passed-by-value
- I believe because of this, closing the Macro Menu would not actually modify `show_macro_menu`.
- Modifying `ShowMacroMenu()` to take a pointer type parameter should ensure `show_macro_menu` will be modified when the Macro Menu is closed
- I tested the original implementation of `ShowMacroMenu()` with my other changes but found the [Issue](https://github.com/GudBoiNero/PrimedKeys/issues/22) would persist unless I made the above changes.

Changes to `Render()`
- After experimenting, I observed that the main loop will keep calling `Render()`, so `gui::ShowMacroMenu()` would always be called even if the Macro Menu were closed.
- In other words, the original implementation of `Render()` would immediately re-render (invoke `ShowMacroMenu()`) if the Macro Menu was closed.
- Wrapping the `gui::ShowMacroMenu()` call in an `if/else` block ensures the Macro Menu will stay closed once the user clicks the close button.
- The `else` statement allows the program to be shut off once the user exits the Macro Menu.


Conclusion
---

Please let me know if other changes are required.

Additionally, if this PR is approved and merged, I'd like this contribution to count towards my [Hacktoberfest 2023](https://hacktoberfest.com/participation/) progress.
If the above changes are approved and merged, could the `hacktoberfest-accepted` label be added to the PR/MR?

Thank you for considering these changes.